### PR TITLE
Add install to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,3 +3,6 @@ lugfetch: lugfetch.cpp
 
 run: lugfetch
 	./lugfetch
+
+install: lugfetch
+	cp ./lugfetch /usr/bin/lugfetch


### PR DESCRIPTION
This PR makes users install lugfetch to `/usr/bin ` using `sudo make install`.